### PR TITLE
Feat: 백엔드 FCM 알림 등록 및 전송 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,4 +265,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# firebase
+/src/main/resources/firebase/
+
 # End of https://www.toptal.com/developers/gitignore/api/macos,windows,intellij,visualstudiocode,linux,netbeans

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,10 @@ dependencies {
     implementation("io.minio:minio:8.5.7")
 //    implementation("io.awspring.cloud:spring-cloud-starter-aws:3.0.2")
 
+
+    //firebase
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
     // test
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/org/fadak/selp/selpbackend/application/controller/FcmTokenController.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/controller/FcmTokenController.java
@@ -1,0 +1,25 @@
+package org.fadak.selp.selpbackend.application.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.fadak.selp.selpbackend.application.service.FcmTokenService;
+import org.fadak.selp.selpbackend.domain.dto.request.FcmTokenRegisterRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/fcmToken")
+@RequiredArgsConstructor
+public class FcmTokenController {
+    private final FcmTokenService fcmTokenService;
+
+    @PostMapping
+    public ResponseEntity<Void> registerFcmToken(@RequestBody FcmTokenRegisterRequestDto request) {
+        long memberId = 1L;
+        fcmTokenService.saveOrUpdateToken(memberId, request);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/java/org/fadak/selp/selpbackend/application/controller/NotificationController.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/controller/NotificationController.java
@@ -1,0 +1,23 @@
+package org.fadak.selp.selpbackend.application.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.fadak.selp.selpbackend.application.service.NotificationService;
+import org.fadak.selp.selpbackend.domain.dto.request.NotificationRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @PostMapping
+    public ResponseEntity<?> registerNotification(@RequestBody NotificationRequestDto dto) {
+        notificationService.registerNotification(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/fadak/selp/selpbackend/application/controller/NotificationController.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/controller/NotificationController.java
@@ -20,4 +20,10 @@ public class NotificationController {
         notificationService.registerNotification(dto);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/send")
+    public ResponseEntity<?> sendNotifications() {
+        notificationService.sendScheduledNotifications();
+        return ResponseEntity.ok().body("전송 완료");
+    }
 }

--- a/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenService.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenService.java
@@ -4,4 +4,5 @@ import org.fadak.selp.selpbackend.domain.dto.request.FcmTokenRegisterRequestDto;
 
 public interface FcmTokenService {
     void saveOrUpdateToken(Long memberId, FcmTokenRegisterRequestDto request);
+    void sendNotification(String fcmToken, String title, String content);
 }

--- a/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenService.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenService.java
@@ -1,0 +1,7 @@
+package org.fadak.selp.selpbackend.application.service;
+
+import org.fadak.selp.selpbackend.domain.dto.request.FcmTokenRegisterRequestDto;
+
+public interface FcmTokenService {
+    void saveOrUpdateToken(Long memberId, FcmTokenRegisterRequestDto request);
+}

--- a/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenServiceImpl.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenServiceImpl.java
@@ -1,23 +1,31 @@
 package org.fadak.selp.selpbackend.application.service;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.fadak.selp.selpbackend.domain.dto.request.FcmTokenRegisterRequestDto;
 import org.fadak.selp.selpbackend.domain.entity.FcmToken;
 import org.fadak.selp.selpbackend.domain.entity.Member;
 import org.fadak.selp.selpbackend.domain.repository.FcmTokenRepository;
 import org.fadak.selp.selpbackend.domain.repository.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Service
 @AllArgsConstructor
+@Slf4j
 public class FcmTokenServiceImpl implements FcmTokenService {
 
     private final FcmTokenRepository fcmTokenRepository;
     private final MemberRepository memberRepository;
+    private final FirebaseMessaging firebaseMessaging;
 
     @Override
+    @Transactional
     public void saveOrUpdateToken(Long memberId, FcmTokenRegisterRequestDto request) {
         Member member = memberRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
         Optional<FcmToken> optionalToken = fcmTokenRepository.findByMemberId(memberId);
@@ -30,6 +38,27 @@ public class FcmTokenServiceImpl implements FcmTokenService {
 
         FcmToken existingToken = optionalToken.get();
         existingToken.updateToken(request.getToken(), request.getDeviceType());
+    }
 
+    @Override
+    @Transactional
+    public void sendNotification(String fcmToken, String title, String content) {
+        try {
+            Notification notification = Notification.builder()
+                    .setTitle(title)
+                    .setBody(content)
+                    .build();
+
+            Message message = Message.builder()
+                    .setToken(fcmToken)
+                    .setNotification(notification)
+                    .build();
+
+            String response = firebaseMessaging.send(message);
+            log.info("FCM 전송 성공 | token={}, response={}", fcmToken, response);
+
+        } catch (Exception e) {
+            log.warn("FCM 전송 실패 | token={}, title={}, error={}", fcmToken, title, e.getMessage());
+        }
     }
 }

--- a/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenServiceImpl.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/service/FcmTokenServiceImpl.java
@@ -1,0 +1,35 @@
+package org.fadak.selp.selpbackend.application.service;
+
+import lombok.AllArgsConstructor;
+import org.fadak.selp.selpbackend.domain.dto.request.FcmTokenRegisterRequestDto;
+import org.fadak.selp.selpbackend.domain.entity.FcmToken;
+import org.fadak.selp.selpbackend.domain.entity.Member;
+import org.fadak.selp.selpbackend.domain.repository.FcmTokenRepository;
+import org.fadak.selp.selpbackend.domain.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class FcmTokenServiceImpl implements FcmTokenService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void saveOrUpdateToken(Long memberId, FcmTokenRegisterRequestDto request) {
+        Member member = memberRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
+        Optional<FcmToken> optionalToken = fcmTokenRepository.findByMemberId(memberId);
+
+        if (optionalToken.isEmpty()) {
+            FcmToken newToken = FcmToken.of(member, request.getToken(), request.getDeviceType());
+            fcmTokenRepository.save(newToken);
+            return;
+        }
+
+        FcmToken existingToken = optionalToken.get();
+        existingToken.updateToken(request.getToken(), request.getDeviceType());
+
+    }
+}

--- a/src/main/java/org/fadak/selp/selpbackend/application/service/NotificationService.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/service/NotificationService.java
@@ -1,0 +1,9 @@
+package org.fadak.selp.selpbackend.application.service;
+
+import org.fadak.selp.selpbackend.domain.dto.request.NotificationRequestDto;
+
+public interface NotificationService {
+    void registerNotification(NotificationRequestDto dto);
+    void sendScheduledNotifications();
+
+}

--- a/src/main/java/org/fadak/selp/selpbackend/application/service/NotificationServiceImpl.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/service/NotificationServiceImpl.java
@@ -1,0 +1,30 @@
+package org.fadak.selp.selpbackend.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.fadak.selp.selpbackend.domain.dto.request.NotificationRequestDto;
+import org.fadak.selp.selpbackend.domain.entity.Member;
+import org.fadak.selp.selpbackend.domain.entity.Notification;
+import org.fadak.selp.selpbackend.domain.repository.MemberRepository;
+import org.fadak.selp.selpbackend.domain.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void registerNotification(NotificationRequestDto dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+                .orElseThrow(IllegalArgumentException::new);
+        Notification notification = Notification.of(member, dto);
+        notificationRepository.save(notification);
+    }
+
+    @Override
+    public void sendScheduledNotifications() {
+
+    }
+}

--- a/src/main/java/org/fadak/selp/selpbackend/application/service/NotificationServiceImpl.java
+++ b/src/main/java/org/fadak/selp/selpbackend/application/service/NotificationServiceImpl.java
@@ -1,19 +1,30 @@
 package org.fadak.selp.selpbackend.application.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.weaver.ast.Not;
 import org.fadak.selp.selpbackend.domain.dto.request.NotificationRequestDto;
+import org.fadak.selp.selpbackend.domain.entity.FcmToken;
 import org.fadak.selp.selpbackend.domain.entity.Member;
 import org.fadak.selp.selpbackend.domain.entity.Notification;
+import org.fadak.selp.selpbackend.domain.repository.FcmTokenRepository;
 import org.fadak.selp.selpbackend.domain.repository.MemberRepository;
 import org.fadak.selp.selpbackend.domain.repository.NotificationRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final MemberRepository memberRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmTokenService fcmTokenService;
 
     @Override
     public void registerNotification(NotificationRequestDto dto) {
@@ -24,7 +35,26 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
+    @Transactional
     public void sendScheduledNotifications() {
+        LocalDate today = LocalDate.now();
+        List<Notification> notifications = notificationRepository.findBySendDateAndIsSent(today, false);
 
+        for(Notification notification : notifications) {
+            Long memberId = notification.getMember().getId();
+            String token = fcmTokenRepository.findByMemberId(memberId)
+                    .map(FcmToken::getToken)
+                    .orElse(null);
+
+            if(token == null) {
+                log.warn("전송 실패: memberId={} → FCM 토큰 없음", memberId);
+                continue;
+            }
+
+            fcmTokenService.sendNotification(token, notification.getTitle(), notification.getContent());
+            notification.setIsSent(true);
+        }
+
+        log.info("FCM 알림 전송 완료: 총 {}건", notifications.size());
     }
 }

--- a/src/main/java/org/fadak/selp/selpbackend/configuration/firebase/FirebaseConfig.java
+++ b/src/main/java/org/fadak/selp/selpbackend/configuration/firebase/FirebaseConfig.java
@@ -3,7 +3,9 @@ package org.fadak.selp.selpbackend.configuration.firebase;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
 import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.FileInputStream;
@@ -12,23 +14,20 @@ import java.io.IOException;
 @Configuration
 public class FirebaseConfig {
 
-    @PostConstruct
-    public void init() {
-        try {
-            FileInputStream serviceAccount =
-                    new FileInputStream("src/main/resources/firebase/firebaseAdminSdk.json");
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        FileInputStream serviceAccount =
+                new FileInputStream("src/main/resources/firebase/firebaseAdminSdk.json");
 
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                    .build();
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
 
-            if (FirebaseApp.getApps().isEmpty()) {
-                FirebaseApp.initializeApp(options);
-                System.out.println("✅ FirebaseApp 초기화 완료");
-            }
-
-        } catch (IOException e) {
-            throw new RuntimeException("Firebase 초기화 실패", e);
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(options);
+            System.out.println("FirebaseApp 초기화 완료");
         }
+
+        return FirebaseMessaging.getInstance();
     }
 }

--- a/src/main/java/org/fadak/selp/selpbackend/configuration/firebase/FirebaseConfig.java
+++ b/src/main/java/org/fadak/selp/selpbackend/configuration/firebase/FirebaseConfig.java
@@ -1,0 +1,34 @@
+package org.fadak.selp.selpbackend.configuration.firebase;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init() {
+        try {
+            FileInputStream serviceAccount =
+                    new FileInputStream("src/main/resources/firebase/firebaseAdminSdk.json");
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                System.out.println("✅ FirebaseApp 초기화 완료");
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("Firebase 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/org/fadak/selp/selpbackend/domain/constant/DeviceType.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/constant/DeviceType.java
@@ -1,0 +1,5 @@
+package org.fadak.selp.selpbackend.domain.constant;
+
+public enum DeviceType {
+    ANDROID, IOS
+}

--- a/src/main/java/org/fadak/selp/selpbackend/domain/dto/request/FcmTokenRegisterRequestDto.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/dto/request/FcmTokenRegisterRequestDto.java
@@ -1,0 +1,14 @@
+package org.fadak.selp.selpbackend.domain.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.fadak.selp.selpbackend.domain.constant.DeviceType;
+
+@Getter
+@Setter
+@Builder
+public class FcmTokenRegisterRequestDto {
+    private String token;
+    private DeviceType deviceType;
+}

--- a/src/main/java/org/fadak/selp/selpbackend/domain/dto/request/NotificationRequestDto.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/dto/request/NotificationRequestDto.java
@@ -1,0 +1,14 @@
+package org.fadak.selp.selpbackend.domain.dto.request;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class NotificationRequestDto {
+    private Long memberId;
+    private Long eventId;
+    private String title;
+    private String content;
+    private LocalDate sendDate;
+}

--- a/src/main/java/org/fadak/selp/selpbackend/domain/entity/FcmToken.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/entity/FcmToken.java
@@ -1,0 +1,41 @@
+package org.fadak.selp.selpbackend.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.fadak.selp.selpbackend.domain.constant.DeviceType;
+
+
+@Getter
+@Entity
+@Table(name = "FCM_TOKEN")
+public class FcmToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "FCM_TOKEN_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID", nullable = false)
+    private Member member;
+
+    @Column(name = "TOKEN", nullable = false, length = 512)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "DEVICE_TYPE")
+    private DeviceType deviceType;
+
+    public static FcmToken of(Member member, String token, DeviceType deviceType) {
+        FcmToken fcmToken = new FcmToken();
+        fcmToken.member = member;
+        fcmToken.token = token;
+        fcmToken.deviceType = deviceType;
+        return fcmToken;
+    }
+
+    public void updateToken(String token, DeviceType deviceType) {
+        this.token = token;
+        this.deviceType = deviceType;
+    }
+}

--- a/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
@@ -48,6 +48,9 @@ public class Notification extends BaseEntity {
     @Column(name = "IS_SENT")
     private Boolean isSent = false;
 
+    @Column(name = "IS_READ")
+    private Boolean isRead = false;
+
     @Column(name = "SEND_DATE")
     private LocalDate sendDate;
 
@@ -58,6 +61,7 @@ public class Notification extends BaseEntity {
                 member,
                 dto.getTitle(),
                 dto.getContent(),
+                false,
                 false,
                 dto.getSendDate()
         );

--- a/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
@@ -15,9 +15,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
+import java.time.LocalDate;
 @Getter
 @Entity
 @Table(name = "NOTIFICATION")
+
 public class Notification extends BaseEntity {
 
     @Id
@@ -32,15 +34,16 @@ public class Notification extends BaseEntity {
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
-    @Column(name = "EVENT_TYPE")
-    private String eventType;
-
     @Column(name = "TITLE")
     private String title;
 
     @Column(name = "CONTENT")
     private String content;
 
-    @Column(name = "IS_READ")
-    private Boolean isRead = false;
+    @Column(name = "IS_SENT")
+    private Boolean isSent = false;
+
+    @Column(name = "SEND_DATE")
+    private LocalDate sendDate;
+
 }

--- a/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
@@ -16,10 +16,12 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.fadak.selp.selpbackend.domain.dto.request.NotificationRequestDto;
 
 import java.time.LocalDate;
 @Getter
+@Setter
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/entity/Notification.java
@@ -13,11 +13,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.fadak.selp.selpbackend.domain.dto.request.NotificationRequestDto;
 
 import java.time.LocalDate;
 @Getter
 @Entity
+@AllArgsConstructor
+@NoArgsConstructor
 @Table(name = "NOTIFICATION")
 
 public class Notification extends BaseEntity {
@@ -45,5 +50,17 @@ public class Notification extends BaseEntity {
 
     @Column(name = "SEND_DATE")
     private LocalDate sendDate;
+
+    public static Notification of(Member member, NotificationRequestDto dto) {
+        return new Notification(
+                null,
+                dto.getEventId(),
+                member,
+                dto.getTitle(),
+                dto.getContent(),
+                false,
+                dto.getSendDate()
+        );
+    }
 
 }

--- a/src/main/java/org/fadak/selp/selpbackend/domain/repository/FcmTokenRepository.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/repository/FcmTokenRepository.java
@@ -1,0 +1,12 @@
+package org.fadak.selp.selpbackend.domain.repository;
+
+
+import org.fadak.selp.selpbackend.domain.entity.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+    Optional<FcmToken> findByMemberId(Long memberId);
+
+}

--- a/src/main/java/org/fadak/selp/selpbackend/domain/repository/NotificationRepository.java
+++ b/src/main/java/org/fadak/selp/selpbackend/domain/repository/NotificationRepository.java
@@ -4,7 +4,11 @@ import org.fadak.selp.selpbackend.domain.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findBySendDateAndIsSent(LocalDate sendDate, Boolean isSent);
 
 }


### PR DESCRIPTION
## 📝 요약(Summary)

- Firebase Admin SDK를 이용해 백엔드에서 FCM 알림 등록 및 전송 기능 구현함
- 현재는 알림 저장 후 수동으로 전송하도록 구성했으며, 추후 스케줄러를 통해 자동 전송으로 변경해야함

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항

아래 쿼리 먼저 실행해야함 
```
ALTER TABLE notification DROP COLUMN event_type;
```
`firebaseAdminSdk.json`은 /src/main/resources/firebase/ 경로에 직접 추가해야 함
→ 파일은 노션에 업로드해둠

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
